### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/new-relic`
-The Paketo New Relic Buildpack is a Cloud Native Buildpack that contributes the [New Relic][n] Agent and configures it to connect to the service.
+The Paketo Buildpack for New Relic is a Cloud Native Buildpack that contributes the [New Relic][n] Agent and configures it to connect to the service.
 
 [n]: https://newrelic.com
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/new-relic"
   id = "paketo-buildpacks/new-relic"
   keywords = ["new-relic", "agent", "apm", "java", "node.js", "php"]
-  name = "Paketo New Relic Buildpack"
+  name = "Paketo Buildpack for New Relic"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo New Relic Buildpack' to 'Paketo Buildpack for New Relic'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
